### PR TITLE
Updated main file.

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "JavaScript Promises on steroids- and more!",
   "author": "Brian Vaughn <briandavidvaughn@gmail.com>",
   "license": "Apache 2.0",
+  "main": "./dist/task-runner.min.js",
   "dependencies": {},
   "devDependencies": {
     "doxx": "~1.2.5",


### PR DESCRIPTION
It looks like the package may not have been exporting properly for npm deployments. I was getting Error: Cannot find module 'task-runner-js'. This change seems to have resolved it for me.